### PR TITLE
Add Ksharp Tokens cleaning

### DIFF
--- a/parser/src/main/kotlin/ksharp/parser/KSharpLexer.kt
+++ b/parser/src/main/kotlin/ksharp/parser/KSharpLexer.kt
@@ -17,6 +17,19 @@ enum class KSharpTokenType : TokenType {
     WhiteSpace,
     NewLine,
     Operator,
+
+    Operator1,
+    Operator2,
+    Operator3,
+    Operator4,
+    Operator5,
+    Operator6,
+    Operator7,
+    Operator8,
+    Operator9,
+    Operator10,
+    Operator11,
+    Operator12
 }
 
 private val mappings = mapOf(
@@ -139,6 +152,40 @@ private fun canCollapseTokens(current: LexerToken, newToken: LexerToken): Boolea
     }
 }
 
+private val operator2 = "*/%".asSequence().toSet()
+private val operator3 = "+-".asSequence().toSet()
+private val operator5 = "<>".asSequence().toSet()
+private val operator6 = "=!".asSequence().toSet()
+private val operator7 = "&".asSequence().toSet()
+private val operator8 = "^".asSequence().toSet()
+private val operator9 = "|".asSequence().toSet()
+
+/// https://docs.ksharp.org/rfc/syntax#operator-precedence
+private fun LexerToken.mapOperatorToken(): LexerToken = when (type) {
+    KSharpTokenType.Operator -> {
+        when {
+            text == "**" -> copy(type = KSharpTokenType.Operator1)
+            text == "<<" || text == ">>" -> copy(type = KSharpTokenType.Operator4)
+            text == "&&" -> copy(type = KSharpTokenType.Operator10)
+            text == "||" -> copy(type = KSharpTokenType.Operator11)
+            text == "=" -> copy(type = KSharpTokenType.Operator12)
+
+            text.isEmpty() -> this
+
+            operator2.contains(text.first()) -> copy(type = KSharpTokenType.Operator2)
+            operator3.contains(text.first()) -> copy(type = KSharpTokenType.Operator3)
+            operator5.contains(text.first()) -> copy(type = KSharpTokenType.Operator5)
+            operator6.contains(text.first()) -> copy(type = KSharpTokenType.Operator6)
+            operator7.contains(text.first()) -> copy(type = KSharpTokenType.Operator7)
+            operator8.contains(text.first()) -> copy(type = KSharpTokenType.Operator8)
+            operator9.contains(text.first()) -> copy(type = KSharpTokenType.Operator9)
+            else -> this
+        }
+    }
+
+    else -> this
+}
+
 fun Iterator<LexerToken>.collapseKSharpTokens(): Iterator<LexerToken> {
     val newTokens = this.collapseTokens()
 
@@ -187,7 +234,7 @@ fun Iterator<LexerToken>.collapseKSharpTokens(): Iterator<LexerToken> {
             return token != null
         }
 
-        override fun next(): LexerToken = token!!
+        override fun next(): LexerToken = token!!.mapOperatorToken()
 
     }
 }

--- a/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
+++ b/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
@@ -58,4 +58,20 @@ class KSharpLexerTest : StringSpec({
                 LexerToken(KSharpTokenType.Operator, TextToken(".", 12, 12)),
             )
     }
+
+    "Given a lexer, check collapse tokens to form function tokens" {
+        "internal->wire.name  ->  wire".lexer(kSharpTokenFactory)
+            .collapseKSharpTokens()
+            .asSequence()
+            .toList().also(::println)
+            .shouldContainAll(
+                LexerToken(KSharpTokenType.FunctionName, TextToken("internal->wire", 0, 13)),
+                LexerToken(KSharpTokenType.Operator, TextToken(".", 14, 14)),
+                LexerToken(KSharpTokenType.LowerCaseWord, TextToken("name", 15, 18)),
+                LexerToken(KSharpTokenType.WhiteSpace, TextToken("  ", 19, 20)),
+                LexerToken(KSharpTokenType.Operator, TextToken("->", 21, 22)),
+                LexerToken(KSharpTokenType.WhiteSpace, TextToken("  ", 23, 24)),
+                LexerToken(KSharpTokenType.LowerCaseWord, TextToken("wire", 25, 28)),
+            )
+    }
 })

--- a/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
+++ b/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
@@ -68,10 +68,24 @@ class KSharpLexerTest : StringSpec({
                 LexerToken(KSharpTokenType.FunctionName, TextToken("internal->wire", 0, 13)),
                 LexerToken(KSharpTokenType.Operator, TextToken(".", 14, 14)),
                 LexerToken(KSharpTokenType.LowerCaseWord, TextToken("name", 15, 18)),
-                LexerToken(KSharpTokenType.WhiteSpace, TextToken("  ", 19, 20)),
                 LexerToken(KSharpTokenType.Operator, TextToken("->", 21, 22)),
-                LexerToken(KSharpTokenType.WhiteSpace, TextToken("  ", 23, 24)),
                 LexerToken(KSharpTokenType.LowerCaseWord, TextToken("wire", 25, 28)),
+            )
+    }
+
+    "Given a lexer, check collapse tokens, should leave really important whitespaces (those after a newline)" {
+        "internal->wire.name = \n    10".lexer(kSharpTokenFactory)
+            .collapseKSharpTokens()
+            .asSequence()
+            .toList().onEach(::println)
+            .shouldContainAll(
+                LexerToken(KSharpTokenType.FunctionName, TextToken("internal->wire", 0, 13)),
+                LexerToken(KSharpTokenType.Operator, TextToken(".", 14, 14)),
+                LexerToken(KSharpTokenType.LowerCaseWord, TextToken("name", 15, 18)),
+                LexerToken(KSharpTokenType.Operator, TextToken("=", 20, 20)),
+                LexerToken(KSharpTokenType.NewLine, TextToken("\n", 22, 22)),
+                LexerToken(KSharpTokenType.WhiteSpace, TextToken("    ", 23, 26)),
+                LexerToken(KSharpTokenType.Integer, TextToken("10", 27, 28)),
             )
     }
 })

--- a/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
+++ b/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
@@ -88,4 +88,93 @@ class KSharpLexerTest : StringSpec({
                 LexerToken(KSharpTokenType.Integer, TextToken("10", 27, 28)),
             )
     }
+
+    "Given a lexer, map operators" {
+        "** *>> //> %%% +++ - << >> <== != & ||| ^& && || = . # $ ?".lexer(kSharpTokenFactory)
+            .collapseKSharpTokens()
+            .asSequence()
+            .toList().onEach(::println)
+            .shouldContainAll(
+                LexerToken(
+                    type = KSharpTokenType.Operator1,
+                    token = TextToken(text = "**", startOffset = 0, endOffset = 1)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator2,
+                    token = TextToken(text = "*>>", startOffset = 3, endOffset = 5)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator2,
+                    token = TextToken(text = "//>", startOffset = 7, endOffset = 9)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator2,
+                    token = TextToken(text = "%%%", startOffset = 11, endOffset = 13)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator3,
+                    token = TextToken(text = "+++", startOffset = 15, endOffset = 17)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator3,
+                    token = TextToken(text = "-", startOffset = 19, endOffset = 19)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator4,
+                    token = TextToken(text = "<<", startOffset = 21, endOffset = 22)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator4,
+                    token = TextToken(text = ">>", startOffset = 24, endOffset = 25)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator5,
+                    token = TextToken(text = "<==", startOffset = 27, endOffset = 29)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator6,
+                    token = TextToken(text = "!=", startOffset = 31, endOffset = 32)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator7,
+                    token = TextToken(text = "&", startOffset = 34, endOffset = 34)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator9,
+                    token = TextToken(text = "|||", startOffset = 36, endOffset = 38)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator8,
+                    token = TextToken(text = "^&", startOffset = 40, endOffset = 41)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator10,
+                    token = TextToken(text = "&&", startOffset = 43, endOffset = 44)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator11,
+                    token = TextToken(text = "||", startOffset = 46, endOffset = 47)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator12,
+                    token = TextToken(text = "=", startOffset = 49, endOffset = 49)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator,
+                    token = TextToken(text = ".", startOffset = 51, endOffset = 51)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator,
+                    token = TextToken(text = "#", startOffset = 53, endOffset = 53)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator,
+                    token = TextToken(text = "$", startOffset = 55, endOffset = 55)
+                ),
+                LexerToken(
+                    type = KSharpTokenType.Operator,
+                    token = TextToken(text = "?", startOffset = 57, endOffset = 57)
+                )
+            )
+    }
 })

--- a/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
+++ b/parser/src/test/kotlin/ksharp/parser/KSharpLexerTest.kt
@@ -68,7 +68,7 @@ class KSharpLexerTest : StringSpec({
                 LexerToken(KSharpTokenType.FunctionName, TextToken("internal->wire", 0, 13)),
                 LexerToken(KSharpTokenType.Operator, TextToken(".", 14, 14)),
                 LexerToken(KSharpTokenType.LowerCaseWord, TextToken("name", 15, 18)),
-                LexerToken(KSharpTokenType.Operator, TextToken("->", 21, 22)),
+                LexerToken(KSharpTokenType.Operator3, TextToken("->", 21, 22)),
                 LexerToken(KSharpTokenType.LowerCaseWord, TextToken("wire", 25, 28)),
             )
     }
@@ -82,7 +82,7 @@ class KSharpLexerTest : StringSpec({
                 LexerToken(KSharpTokenType.FunctionName, TextToken("internal->wire", 0, 13)),
                 LexerToken(KSharpTokenType.Operator, TextToken(".", 14, 14)),
                 LexerToken(KSharpTokenType.LowerCaseWord, TextToken("name", 15, 18)),
-                LexerToken(KSharpTokenType.Operator, TextToken("=", 20, 20)),
+                LexerToken(KSharpTokenType.Operator12, TextToken("=", 20, 20)),
                 LexerToken(KSharpTokenType.NewLine, TextToken("\n", 22, 22)),
                 LexerToken(KSharpTokenType.WhiteSpace, TextToken("    ", 23, 26)),
                 LexerToken(KSharpTokenType.Integer, TextToken("10", 27, 28)),


### PR DESCRIPTION
1. Collapse Lower, Upper and Operators (except .) to form function names. Stop doing this if a whitespace is found
2. Map operators tokens to precedence tokens